### PR TITLE
Justeringsförslag 14.10.2022

### DIFF
--- a/bingoregler.md
+++ b/bingoregler.md
@@ -1,38 +1,44 @@
 # Bingoregler
 
-## § 1
+## Kapitel 1: Justering av reglerna
+### § 1
 Bingoreglerna kan när som helst läggas till omröstning för att justeras.
-### § 1.1
-Enkel omröstning kan enbart justera ett enskilt ord eller tecken i reglerna, men kräver bara att 50 % av rösterna är för justeringen.
-### § 1.2
-Avancerad omröstning kan justera reglerna helt fritt, men kräver att 100 % av rösterna är för justeringen.
-### § 1.3
+#### § 1.1
+Enkel omröstning kan enbart justera ett enskilt tecken i reglerna och kräver att minst 50 % av rösterna är för justeringen.
+#### § 1.2
+Avancerad omröstning kan justera reglerna helt fritt och kräver att 100 % av rösterna är för justeringen.
+#### § 1.3
 Då justeringen är gjord, ska detta antecknas på samtliga deltagares regler (eller annat smidigt ställe) så att allas regler överensstämmer med justeringen.
-### § 1.4
+#### § 1.4
 Justering av bingoreglerna påverkar inte tidigare bedömningar.
-### § 1.5
+#### § 1.5
 Reglerna bör under alla omständigheter och i alla enskilda ögonblick vara skrivna på god svenska, logiska, och förenliga med god sed samt gällande finsk lagstiftning.
-## § 2
+#### § 1.6
+Justering av reglerna på det sätt som anges i § 1.1-2 gäller inte ifrågavarande punkter. Omröstningsförfarandena kan alltså inte justeras.
+## Kapitel 2: Bingorutornas innehåll
+### § 2
 Texten i en ruta är att tolka som ett kriterium för att rutan ska uppfyllas. Då kriteriet uppfylls får samtliga deltagare kryssa av rutan.
-### § 2.1
+#### § 2.1
 En bingorutas kriterium måste nämna en, och endast en, medlem i sällskapet.
-### § 2.2
+#### § 2.2
 Bingorutan i mitten är en joker, d.v.s. den utgör ett konstant uppfyllt kriterium och behöver inte separat avkryssas.
-## § 3
+## Kapitel  3: Målsättningar och priser
+### § 3
 “Enkel” bingo uppnås då fem rutor i rad (horisontellt, vertikalt eller diagonalt) är avkryssade på en spelares bingobricka.
-### § 3.1
-Då någon uppnår enkel bingo ska övriga deltagare ta en sup av valfri dryck.
-## § 4
+#### § 3.1
+Då någon uppnår enkel bingo ska övriga deltagare ta en sup av valfri dryck till dennes ära.
+### § 4
 Med “dubbel” bingo avses den andra gången en deltagare uppnår enkel bingo, d.v.s. då två serier av fem rutor i rad på det sätt som anges i § 3 är avkryssade.
-### § 4.1
+#### § 4.1
 Då någon uppnår dubbel bingo ska övriga deltagare buga inför den som uppnåt den dubbla bingon samt ta en sup av valfri dryck.
-## § 5
+### § 5
 Med “trippel” bingo avses den tredje gången en deltagare uppnår enkel bingo på motsvarande sätt som i § 4, dock med tre serier istället för två.
-### § 5.1
+#### § 5.1
 Då någon uppnår trippel bingo är det dennes privilegium att för sällskapet föreslå de övrigas öde, i utbyte mot att de övriga får ställa ett kriterium som denne först måste uppfylla för att deras öde ska förverkligas.
-## § 6
-Om ett kriterium i en bingoruta inte längre går att uppnå kan texten i rutan justeras på samma sätt som är angivet för bingoreglerna i § 1, dock så att § 2.1 respekteras.
-## § 7
+## Kapitel 4: Spelflöde
+### § 6
+Om ett kriterium i en bingoruta inte längre går att uppnå kan texten i rutan justeras på samma sätt som är angivet för bingoreglerna i § 1, dock så att Kapitel 2 respekteras.
+### § 7
 Ifall någon får mer än trippel bingo behöver det övriga sällskapet enhälleligt bestämma vad som händer.
-## § 8
-Bingon avslutas då alla bingorutor är ikryssade.
+### § 8
+Bingon avslutas då alla bingorutor är ikryssade eller genom en omröstning där samtliga deltagare är överens om att avsluta bingon.

--- a/bingoregler.md
+++ b/bingoregler.md
@@ -16,6 +16,8 @@ Reglerna bör under alla omständigheter och i alla enskilda ögonblick vara skr
 Texten i en ruta är att tolka som ett kriterium för att rutan ska uppfyllas. Då kriteriet uppfylls får samtliga deltagare kryssa av rutan.
 ### § 2.1
 En bingorutas kriterium måste nämna en, och endast en, medlem i sällskapet.
+### § 2.2
+Bingorutan i mitten är en joker, d.v.s. den utgör ett konstant uppfyllt kriterium och behöver inte separat avkryssas.
 ## § 3
 “Enkel” bingo uppnås då fem rutor i rad (horisontellt, vertikalt eller diagonalt) är avkryssade på en spelares bingobricka.
 ### § 3.1


### PR DESCRIPTION
I föregående version av bingoregler, kunde justeringsreglerna utnyttjas för att uppnå en orättvis fördel. Genom att begränsa den enkla omröstningsmöjligheten till enbart tecken och exkludera omröstningsreglerna från vad som kan justeras undviks detta.
Därtill en del rubrikförtydliganden.